### PR TITLE
Load json file as string rather than bytes.

### DIFF
--- a/pycity/__init__.py
+++ b/pycity/__init__.py
@@ -3,7 +3,7 @@ import json
 
 class Database(object):
     def __init__(self, filename):
-        f = open(filename, 'rb')
+        f = open(filename, 'r')
         json_data = f.read()
         self.data = json.loads(json_data)
 


### PR DESCRIPTION
json.loads() refused to read bytes object. Addressed by reading as string rather than bytes object.

Not sure if this changes affects much else.

Maybe this is Python3.5 specific or something I may have missed.

```Traceback (most recent call last):
  File "/mnt/m/automation/lib/python3.5/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/mnt/m/AutomationProof/main.py", line 1, in <module>
    from app import dpj, database, migrate
  File "/mnt/m/AutomationProof/app/__init__.py", line 64, in <module>
    from app import views, models, database, migrate
  File "/mnt/m/AutomationProof/app/views.py", line 6, in <module>
    from app.forms import (
  File "/mnt/m/AutomationProof/app/forms.py", line 10, in <module>
    import pycity
  File "/mnt/m/automation/lib/python3.5/site-packages/pycity/__init__.py", line 24, in <module>
    cities = Cities(os.path.join(DATABASE_DIR, 'cities.json'))
  File "/mnt/m/automation/lib/python3.5/site-packages/pycity/__init__.py", line 8, in __init__
    self.data = json.loads(json_data)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'```